### PR TITLE
Add Codecov shared settings

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,3 +29,5 @@ jobs:
         if: "${{ matrix.node-version == '14.x' }}"
       - name: Tests
         run: npm run test:ci
+      - name: Codecov test coverage
+        run: bash bin/report_coverage.sh "${{ matrix.os }}" "${{ matrix.node-version }}"

--- a/bin/report_coverage.sh
+++ b/bin/report_coverage.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Upload test coverage to Codecov
+# We need to use a Bash script instead of using a npm script or the official
+# GitHub action because we want to send OS and Node.js version as flags.
+# Codecov does not support dots nor dashes in flags. However, GitHub actions
+# variables for those do, so we need to strip them.
+
+os="$1"
+os="${os/-latest/}"
+
+node="$2"
+node="node_${node//./_}"
+
+# We don't use the -Z flag (which makes CI build fail on upload error) and we
+# use the --fail flag (which does not make CI build fail on curl error) because
+# Codecov API fails too often.
+curl --fail -s https://codecov.io/bash | \
+  bash -s -- -f coverage/coverage-final.json -F "$os" -F "$node"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  strict_yaml_branch: master
+coverage:
+  range: [80, 100]
+  parsers:
+    javascript:
+      enable_partials: true
+  status:
+    project: false
+    patch: false
+comment: false

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "bin"
   ],
   "bin": {
-    "run-e": "./bin/run_e.js"
+    "run-e": "./bin/run_e.js",
+    "report_coverage": "./bin/report_coverage.sh"
   },
   "scripts": {
     "test": "run-s format test:dev",


### PR DESCRIPTION
This adds the Codecov Bash upload script as a binary exposed by `@netlify/eslint-config-node` so that consumers don't need to copy this file anymore in their repository.