### PR TITLE
Add `no-nonoctal-decimal-escape` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
     'no-multi-assign': 2,
     'no-negated-condition': 2,
     'no-nested-ternary': 2,
+    'no-nonoctal-decimal-escape': 2,
     'no-param-reassign': [
       2,
       {


### PR DESCRIPTION
This adds the new [`no-nonoctal-decimal-escape` ESLint rule](https://eslint.org/docs/rules/no-nonoctal-decimal-escape) added in the latest ESLint upgrade.