### PR TITLE
Remove `eslint-plugin-standard`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,11 +1974,6 @@
         }
       }
     },
-    "eslint-plugin-standard": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ=="
-    },
     "eslint-plugin-unicorn": {
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-23.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-standard": "^4.0.1",
     "eslint-plugin-unicorn": "^23.0.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.10.0",
     "execa": "^4.0.3",


### PR DESCRIPTION
This removes `eslint-plugin-standard`. That plugin [is deprecated](https://github.com/standard/standard/issues/1316) and not used in our ESLint configuration anyway.
This is in contrast to [`eslint-config-standard`](https://github.com/standard/eslint-config-standard) which we do use.