### PR TITLE
Add `no-unsafe-optional-chaining` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,6 +119,7 @@ module.exports = {
     'no-shadow': 2,
     'no-underscore-dangle': [2, { enforceInMethodNames: true }],
     'no-undef': [2, { typeof: true }],
+    'no-unsafe-optional-chaining': [2, { disallowArithmeticOperators: true }],
     'no-unused-vars': [2, {}],
     'no-useless-computed-key': [2, { enforceForClassMembers: true }],
     'no-useless-concat': 2,


### PR DESCRIPTION
This adds the [`no-unsafe-optional-chaining` rule](https://eslint.org/docs/rules/no-unsafe-optional-chaining) which was added by the latest version of ESLint. 
We cannot use optional chaining yet until we drop support for Node 12, but this is a good rule to add for the future, and it does not hurt to add it already.