### PR TITLE
Add `arrow-body-style` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     // Those ESLint rules are not enabled by Prettier, ESLint recommended rules
     // nor standard JavaScript. However, they are still useful
     'array-callback-return': [2, { allowImplicit: true, checkForEach: true }],
+    'arrow-body-style': 2,
     'block-scoped-var': 2,
     'class-methods-use-this': 2,
     complexity: [2, 5],


### PR DESCRIPTION
This adds the [`arrow-body-style` ESLint rule](https://eslint.org/docs/rules/arrow-body-style).

This rule was previously in conflict with `eslint-config-prettier`, but not anymore with the latest version.

This rule turns `(args) => { return value }` into `(args) => value`. It autofixes all warnings.