### PR TITLE
Add `prefer-arrow-callback` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -126,6 +126,7 @@ module.exports = {
     'object-shorthand': 2,
     'operator-assignment': 2,
     'padding-line-between-statements': 2,
+    'prefer-arrow-callback': [2, { allowNamedFunctions: true }],
     'prefer-destructuring': 2,
     'prefer-exponentiation-operator': 2,
     'prefer-numeric-literals': 2,


### PR DESCRIPTION
This adds the [`prefer-arrow-callback` ESLint rule](https://eslint.org/docs/rules/prefer-arrow-callback).

This rule was previously incompatible with `eslint-config-prettier` and Prettier, but that's not the case anymore with its latest version.