### PR TITLE
Add `429` to `no-magic-numbers`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,6 +85,7 @@ module.exports = {
           404,
           410,
           422,
+          429,
           500,
         ],
         enforceConst: true,


### PR DESCRIPTION
This PR tweaks the `no-magic-numbers` rule to add `429` HTTP status code.