### PR TITLE
fix: add missing linting configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "main": ".eslintrc.js",
   "files": [
     ".eslintrc.js",
+    "react_config.js",
+    "vanilla_js_config.js",
     ".prettierrc.json",
     ".editorconfig",
     ".gitattributes",


### PR DESCRIPTION
Follow up on https://github.com/netlify/eslint-config-node/pulls?q=is%3Apr+is%3Aclosed