### PR TITLE
fix(eslint-react): disable unicorn/import-index

### DIFF
--- a/react_config.js
+++ b/react_config.js
@@ -22,6 +22,7 @@ module.exports = {
       rules: {
         'unicorn/filename-case': 0,
         'node/no-unsupported-features/es-syntax': 0,
+        'unicorn/import-index': 0,
       },
     },
   ],


### PR DESCRIPTION
This rule conflicts with `import/extensions`