### PR TITLE
Upgrade Unicorn plugin to `26.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2281,16 +2281,16 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-25.0.1.tgz",
-      "integrity": "sha512-MEyEWoyou/qhJH6rEER9YHACtCsQT+eewc6Fdxbi2eiTvsGrBR8JZMA6qaeof3oMQeRxOpaERoBKzU7R5c4A/w==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-26.0.0.tgz",
+      "integrity": "sha512-7eBSBJ2SnPwmhXczn7vfBLKbVIJtgmmv5ohxi4H2gKmZrjswkBXt2ydPKi5wmQTvHUPk564VCBbw1kfrlwCe7Q==",
       "requires": {
         "ci-info": "^2.0.0",
         "clean-regexp": "^1.0.0",
         "eslint-ast-utils": "^1.1.0",
-        "eslint-template-visitor": "^2.2.1",
+        "eslint-template-visitor": "^2.2.2",
         "eslint-utils": "^2.1.0",
-        "import-modules": "^2.0.0",
+        "import-modules": "^2.1.0",
         "lodash": "^4.17.20",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-unicorn": "^25.0.0",
+    "eslint-plugin-unicorn": "^26.0.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.10.0",
     "execa": "^5.0.0",
     "husky": "^4.3.0",


### PR DESCRIPTION
This upgrades [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v26.0.0) to `26.0.0`.