### PR TITLE
chore: disable `unicorn/no-array-for-each` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -267,6 +267,7 @@ module.exports = {
     // Too strict
     'unicorn/no-null': 0,
     'unicorn/no-array-reduce': 0,
+    'unicorn/no-array-for-each': 0,
     // This rule gives too many false positives
     'unicorn/prevent-abbreviations': 0,
     // Conflicts with Prettier sometimes


### PR DESCRIPTION
This disables the [`unicorn/no-array-for-each` ESLint rule](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md) which was introduced by `eslint-plugin-unicorn@27.0.0` (https://github.com/netlify/eslint-config-node/pull/92). This rule is too restrictive. Also, there are cases where `Array.forEach()` is more readable than a more loop.