### PR TITLE
fix(deps): use @babel/eslint-parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   parserOptions: {
+    requireConfigFile: false,
     sourceType: 'script',
   },
   plugins: ['markdown', 'html', 'fp'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
       "version": "2.5.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@babel/core": "^7.13.8",
+        "@babel/eslint-parser": "^7.13.8",
         "@commitlint/cli": "^12.0.0",
         "@commitlint/config-conventional": "^12.0.0",
-        "babel-eslint": "^10.1.0",
         "cross-env": "^7.0.2",
-        "eslint": "^7.11.0",
+        "eslint": "^7.21.0",
         "eslint-config-prettier": "^8.0.0",
         "eslint-config-standard": "^16.0.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -37,8 +38,6 @@
         "run-e": "bin/run_e.js"
       },
       "devDependencies": {
-        "@commitlint/cli": "^12.0.0",
-        "@commitlint/config-conventional": "^12.0.0",
         "ava": "^3.13.0",
         "nyc": "^15.1.0"
       },
@@ -1219,26 +1218,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
       }
     },
     "node_modules/bail": {
@@ -8938,19 +8917,6 @@
             "yargs-parser": "^20.2.2"
           }
         }
-      }
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
       }
     },
     "bail": {

--- a/package.json
+++ b/package.json
@@ -73,11 +73,12 @@
     "test": "test"
   },
   "dependencies": {
+    "@babel/core": "^7.13.8",
+    "@babel/eslint-parser": "^7.13.8",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
-    "babel-eslint": "^10.1.0",
     "cross-env": "^7.0.2",
-    "eslint": "^7.11.0",
+    "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-config-standard": "^16.0.0",
     "eslint-import-resolver-node": "^0.3.4",
@@ -98,8 +99,6 @@
     "prettier": "^2.1.2"
   },
   "devDependencies": {
-    "@commitlint/cli": "^12.0.0",
-    "@commitlint/config-conventional": "^12.0.0",
     "ava": "^3.13.0",
     "nyc": "^15.1.0"
   },


### PR DESCRIPTION
**Which problem is this pull request solving?**

`babel-eslint` is deprecated - this PR switches to `@babel/eslint-parser`

**Checklist**

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
