### PR TITLE
chore: rename master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,4 +35,4 @@ please copy/paste the deploy logs below instead.
 **Pull requests**
 
 Pull requests are welcome! If you would like to help us fix this bug, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -36,5 +36,5 @@ Yes/No.
 
 <!--
 Pull requests are welcome! If you would like to help us add this feature, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,5 +26,5 @@ Example: Another solution would be [...]
 
 Please add a `x` inside each checkbox:
 
-- [ ] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
+- [ ] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
 - [ ] The status checks are successful (continuous integration). Those can be seen below.

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   # Ensure GitHub actions are not run twice for same commits
   push:
-    branches: [master]
+    branches: [main]
     tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module.exports = { extends: ['@commitlint/config-conventional'] }
 - Add the following properties to the `package.json`. Please replace the `config` globbing expressions to match the
   files where the source JavaScript/Markdown/HTML/JSON/YAML files are located. `npm run format` should also be run
   during `npm test` and `npm run format:ci` during CI
-  ([example](https://github.com/netlify/cli/blob/master/.github/workflows/main.yml)).
+  ([example](https://github.com/netlify/cli/blob/main/.github/workflows/main.yml)).
 
 ```json
 {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  strict_yaml_branch: master
+  strict_yaml_branch: main
 coverage:
   range: [80, 100]
   parsers:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:dev:ava": "ava",
     "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
     "prepublishOnly": "run-s prepublishOnly:*",
-    "prepublishOnly:checkout": "git checkout master",
+    "prepublishOnly:checkout": "git checkout main",
     "prepublishOnly:pull": "git pull",
     "prepublishOnly:install": "npm ci",
     "prepublishOnly:test": "npm test"

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,6 +2,6 @@
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
-  masterIssue: true,
+  dependencyDashboard: true,
   automerge: false,
 }


### PR DESCRIPTION
Following up on the default branch renaming `master->main`:
Related to https://github.com/netlify/team-dev/issues/6