### PR TITLE
chore: add missing id to release-please step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
         with:
           token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
           release-type: node


### PR DESCRIPTION
This adds a missing id to the `release-please` to fix `npm` publishing.
See https://github.com/netlify/eslint-config-node/runs/2217534932?check_suite_focus=true