### PR TITLE
fix: disable prefer-node-protocol

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -269,6 +269,8 @@ module.exports = {
     'unicorn/no-array-reduce': 0,
     'unicorn/no-array-for-each': 0,
     'unicorn/prefer-module': 0,
+    // Conflicts with no-unresolved and no-missing-import
+    'unicorn/prefer-node-protocol':0,
     // This rule gives too many false positives
     'unicorn/prevent-abbreviations': 0,
     // Conflicts with Prettier sometimes

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -270,7 +270,7 @@ module.exports = {
     'unicorn/no-array-for-each': 0,
     'unicorn/prefer-module': 0,
     // Conflicts with no-unresolved and no-missing-import
-    'unicorn/prefer-node-protocol':0,
+    'unicorn/prefer-node-protocol': 0,
     // This rule gives too many false positives
     'unicorn/prevent-abbreviations': 0,
     // Conflicts with Prettier sometimes


### PR DESCRIPTION
`no-unresolved` and `no-missing-import` don't recognize the node protocol yet (e.g they error on `node:buffer`).

Related to https://github.com/netlify/gotrue-js/pull/345