### PR TITLE
fix: disable unicorn flat and flatmap rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -270,6 +270,8 @@ module.exports = {
     'unicorn/prefer-string-trim-start-end': 0,
     // TODO: enable after dropping Node <12 support
     'unicorn/numeric-separators-style': 0,
+    'unicorn/prefer-array-flat': 0,
+    'unicorn/prefer-array-flat-map': 0,
   },
   overrides: [
     {


### PR DESCRIPTION
**Which problem is this pull request solving?**

See https://github.com/sindresorhus/eslint-plugin-unicorn/pull/1210.
https://github.com/netlify/js-client/pull/415 and https://github.com/netlify/zip-it-and-ship-it/pull/461 are failing because of this change.

My expectation was that these rules won't be checked when the library support Node.js versions < 12.
I'm not sure this warrants an issue on the `unicorn` repo as they support Node.js >=12.

**Describe the solution you've chosen**

Disable the rule until we drop Node.js 12 support

**Describe alternatives you've considered**

Fix this in each repo

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
