### PR TITLE
fix: import/extensions rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,7 +194,7 @@ module.exports = {
       },
     ],
 
-    'import/extensions': [2, 'always', { ignorePackages: true }],
+    'import/extensions': [2, 'never'],
     'import/max-dependencies': [2, { max: 20 }],
     'import/newline-after-import': 2,
     'import/no-amd': 2,


### PR DESCRIPTION
It appears that the [latest minor update](https://github.com/netlify/eslint-config-node/pull/186) of `eslint-plugin-import` had breaking changes which is making linting fail on some repositories ([example](https://github.com/netlify/js-client/pull/426/checks?check_run_id=2596497044)).

This PR fixes this.