### PR TITLE
chore(ci): prelease action

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,42 @@
+name: prerelease
+on:
+  push:
+    branches:
+      # releases/<tag>/<version>
+      - releases/*/*
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '*'
+          check-latest: true
+          registry-url: 'https://registry.npmjs.org'
+      - name: Extract tag and version
+        id: extract
+        run: |-
+          ref=${{ github.ref }}
+          branch=${ref:11}
+          tag_version=${branch:9}
+          tag=${tag_version%/*}
+          version=${tag_version##*/}
+          echo "::set-output name=tag::${tag}"
+          echo "::set-output name=version::${version}"
+      - name: Log versions
+        run: |-
+          echo tag=${{ steps.extract.outputs.tag }}
+          echo version=${{ steps.extract.outputs.version }}
+      - name: Setup git user
+        run: git config --global user.name github-actions
+      - name: Setup git email
+        run: git config --global user.email github-actions@github.com
+      - name: Run npm version
+        run: npm version ${{ steps.extract.outputs.version }}-${{ steps.extract.outputs.tag }}
+      - name: Push changes
+        run: git push --follow-tags
+      - name: Run npm publish
+        run: npm publish --tag=${{ steps.extract.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,11 @@ After submitting the pull request, please make sure the Continuous Integration c
 ## Releasing
 
 1. Merge the release PR
+
+### Creating a prerelease
+
+1. Create a branch named `releases/<tag>/<version>` with the version you'd like to release.
+2. Push the branch to the repo.
+
+For example, a branch named `releases/rc/4.0.0` will create the version `v4.0.0-rc` and will publish it under the `rc`
+tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,5 +45,4 @@ After submitting the pull request, please make sure the Continuous Integration c
 1. Create a branch named `releases/<tag>/<version>` with the version you'd like to release.
 2. Push the branch to the repo.
 
-For example, a branch named `releases/rc/4.0.0` will create the version `v4.0.0-rc` and will publish it under the `rc`
-tag
+For example, a branch named `releases/rc/4.0.0` will create the version `v4.0.0-rc` and publish it under the `rc` tag.


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds a GitHub action to automate prereleases.

It doesn't have fancy changelogs or GitHub releases, but still good for testing purposes.

See branch https://github.com/netlify/eslint-config-node/tree/releases/test/4.0.0
See tag https://github.com/netlify/eslint-config-node/releases/tag/v4.0.0-test
See `npm` https://www.npmjs.com/package/@netlify/eslint-config-node

![image](https://user-images.githubusercontent.com/26760571/123678700-54b38800-d84f-11eb-9757-dd09fceee73a.png)

> I'll remove the tag, branch and deprecate the published package once the PR is merged

**List other issues or pull requests related to this problem**

Related to https://github.com/netlify/team-dev/issues/25

**Checklist**

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
