### PR TITLE
fix: disable `unicorn/prefer-object-from-entries`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -222,6 +222,7 @@ module.exports = {
     'unicorn/no-array-reduce': 0,
     'unicorn/no-array-for-each': 0,
     'unicorn/prefer-module': 0,
+    'unicorn/prefer-object-from-entries': 0,
     // Conflicts with no-unresolved and no-missing-import
     'unicorn/prefer-node-protocol': 0,
     // This rule gives too many false positives


### PR DESCRIPTION
This disables the [`unicorn/prefer-object-from-entries` ESLint rule](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-object-from-entries.md). It is too strict (it forbids almost all `array.reduce()`) and [gets over-reported on the CLI repository](https://github.com/netlify/cli/pull/3120/checks?check_run_id=3279680274).