### PR TITLE
chore: enable kodiak automerge by dependency type

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,1 +1,5 @@
 version = 1
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["renovate"]

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,5 +3,6 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   dependencyDashboard: true,
-  automerge: true,
+  automerge: false,
+  rebaseWhen: 'conflicted',
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Better manage CI resources for dependencies PRs using Kodiak

**List other issues or pull requests related to this problem**

See https://github.com/chdsbd/kodiak/issues/701#issuecomment-899352840

**Describe the solution you've chosen**

Implements the flow from https://github.com/chdsbd/kodiak/issues/701#issuecomment-899352840
1. Sets Kodiak to auto merge renovate patch and minor updates. Kodiak will sync those with the default branch before merging.
2. Tells renovate not to auto merge those, so those PRs don't skip the PRs queue.
3. Tells renovate to rebase PRs only when they are conflicted (instead when the are 1 commit behind the default branch).

**Describe alternatives you've considered**

Letting renovate rebase+automerge and waste CI resources.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.

> If this works well I'll apply it to the [default configuration](https://github.com/netlify/renovate-config/blob/main/default.json)