### PR TITLE
fix: `import/no-cycle` rule makes linting fail in CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,7 +149,7 @@ module.exports = {
     'import/newline-after-import': 2,
     'import/no-amd': 2,
     'import/no-anonymous-default-export': 2,
-    'import/no-cycle': [2, { commonjs: true }],
+    'import/no-cycle': 2,
     'import/no-deprecated': 2,
     'import/no-dynamic-require': [2, { esmodule: true }],
     'import/no-extraneous-dependencies': 2,


### PR DESCRIPTION
Fixes https://github.com/netlify/cli/issues/3280

`eslint-plugin-import` [seems to have a bug](https://github.com/import-js/eslint-plugin-import/issues?q=%22is+invalid+and+will+just+be+ignored%22) where the `node_modules` is being linted even though it is being explicitly ignored in our configuration ([through `--ignore-path .gitignore`](https://github.com/netlify/cli/blob/587e606a8701b8109ef5ea67acd69983a0744d2d/package.json#L76)).

This makes linting fail in multiple repositories.

Removing CommonJS support for the `no-cycle` rule seems to be fixing this problem.