### PR TITLE
feat: add Cypress linting configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -324,6 +324,17 @@ module.exports = {
         'import/extensions': [2, 'always'],
       },
     },
+    // Cypress test files
+    {
+      files: ['cypress/**/*.js'],
+      parserOptions: {
+        sourceType: 'module',
+      },
+      env: {
+        'cypress/globals': true,
+      },
+      plugins: ['cypress'],
+    },
   ],
   settings: {
     'import/parsers': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-import-resolver-node": "^0.3.4",
         "eslint-import-resolver-typescript": "^2.5.0",
         "eslint-plugin-ava": "^13.0.0",
+        "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-fp": "^2.3.0",
         "eslint-plugin-html": "^6.1.0",
@@ -36,7 +37,7 @@
         "husky": "^4.3.0",
         "is-ci": "^3.0.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "^2.5.0",
+        "prettier": "^2.1.2",
         "statuses": "^2.0.1"
       },
       "bin": {
@@ -3065,6 +3066,17 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-cypress": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
+      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "dependencies": {
+        "globals": "^11.12.0"
+      },
+      "peerDependencies": {
+        "eslint": ">= 3.2.1"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -10821,6 +10833,14 @@
             "eslint-visitor-keys": "^3.0.0"
           }
         }
+      }
+    },
+    "eslint-plugin-cypress": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
+      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "requires": {
+        "globals": "^11.12.0"
       }
     },
     "eslint-plugin-es": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-ava": "^13.0.0",
+    "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-html": "^6.1.0",


### PR DESCRIPTION
This adds some linting configuration for Cypress testing files.

This was taken [from `framework-info`](https://github.com/netlify/framework-info/blob/827ab91e844f28a53dc9c6b6eb6e2e02be84b1ac/.eslintrc.js#L16). Once this is released, we can remove it there, and also remove `eslint-plugin-cypress` from that repository.

This will ensure we will Cypress testing files across our repositories and only update `eslint-plugin-cypress` in a single repository.