### PR TITLE
fix(deps): downgrade eslint-plugin-promise to v5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,15 @@
         "@babel/eslint-parser": "^7.13.8",
         "@commitlint/cli": "^16.0.0",
         "@commitlint/config-conventional": "^16.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.9.0",
-        "@typescript-eslint/parser": "^5.9.0",
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "@typescript-eslint/parser": "^5.0.0",
         "cross-env": "^7.0.2",
         "eslint": "^7.21.0",
         "eslint-config-prettier": "^8.0.0",
         "eslint-config-standard": "^16.0.0",
         "eslint-import-resolver-node": "^0.3.4",
         "eslint-import-resolver-typescript": "^2.5.0",
-        "eslint-plugin-ava": "^13.2.0",
+        "eslint-plugin-ava": "^13.0.0",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-fp": "^2.3.0",
@@ -29,7 +29,7 @@
         "eslint-plugin-import": "^2.25.1",
         "eslint-plugin-markdown": "^2.0.0",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-promise": "^5.2.0",
         "eslint-plugin-react": "^7.21.5",
         "eslint-plugin-unicorn": "^39.0.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.10.0",
@@ -3319,14 +3319,14 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
-      "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
+      "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^10.12.0 || >=12.0.0"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -11071,9 +11071,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
-      "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
+      "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
       "requires": {}
     },
     "eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-import": "^2.25.1",
     "eslint-plugin-markdown": "^2.0.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.0.0",
+    "eslint-plugin-promise": "^5.2.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-unicorn": "^39.0.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.10.0",


### PR DESCRIPTION
eslint-config-standard does not support eslint-plugin-promise v6 yet.

Reverts #380.

The plugin should be updated later when there are no install errors, probably in #321 and after eslint-config-standard is updated to support ESLint 8.x and `eslint-plugin-promise@6`.

---

🎉 Thanks for sending this pull request! 🎉

Please make sure the title is clear and descriptive.

If you are fixing a typo or documentation, please skip these instructions.

Otherwise please fill in the sections below.

**Which problem is this pull request solving?**

Example: I'm always frustrated when [...]

**List other issues or pull requests related to this problem**

Example: This fixes #5012

**Describe the solution you've chosen**

Example: I've fixed this by [...]

**Describe alternatives you've considered**

Example: Another solution would be [...]

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
