### PR TITLE
chore: remove `pre-commit` hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm test


### PR DESCRIPTION
We currently enforce the following Git hooks:
  - `commitlint` on new commit messages
  - Linting/Prettier on `git push`

https://github.com/netlify/eslint-config-node/pull/403 added a new Git hook: `npm test` on new commits.

While this is good for code quality, I believe this might not work since some of our repositories have some pretty big test suites. Running those on each commit, as opposed to each `git push` might slow us down.

This PR reverts this new Git hook. Please let me know what you think!

cc @XhmikosR 

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
