### PR TITLE
fix: `commitlint` Git hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-commitlint -E HUSKY_GIT_PARAMS
+commitlint --edit "$1"


### PR DESCRIPTION
Since upgrading to the latest version of Husky https://github.com/netlify/eslint-config-node/pull/403, the `commitlint` Git hook is now failing with:

```
/home/user/netlify/js-client/node_modules/@commitlint/cli/lib/cli.js:112
        throw err;
        ^

Error: Received 'HUSKY_GIT_PARAMS' as value for -E | --env, but environment variable 'HUSKY_GIT_PARAMS' is not available globally
    at getEditValue (/home/user/netlify/js-client/node_modules/@commitlint/cli/lib/cli.js:273:19)
    at normalizeFlags (/home/user/netlify/js-client/node_modules/@commitlint/cli/lib/cli.js:267:18)
    at main (/home/user/netlify/js-client/node_modules/@commitlint/cli/lib/cli.js:147:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

Node.js v17.3.1
husky - commit-msg hook exited with code 1 (error)
```

Looking at Husky's and commitlint documentation, it appears the new version of Husky might require rewriting this hook, which this PR does. I tried it locally and this seems to work.

cc @XhmikosR 

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
