### PR TITLE
fix: add `npx` to `commitlint`

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-commitlint --edit "$1"
+npx commitlint --edit "$1"


### PR DESCRIPTION
In order to find `commitlint`'s binary, `npx` must be used.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
