### PR TITLE
fix: remove broken duplicate rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,6 @@ module.exports = {
     'multiline-comment-style': [2, 'separate-lines'],
     'no-bitwise': 2,
     'no-constructor-return': 2,
-    'no-duplicate-imports': 2,
     'no-else-return': [2, { allowElseIf: false }],
     'no-extra-label': 2,
     'no-implicit-coercion': 2,


### PR DESCRIPTION
This PR removes the rule `no-duplicate-imports`. It attempts to do the same as `import/no-duplicates`, but it does not understand TypeScript's need to have separate imports for `import type {...` and `import {...`