### PR TITLE
chore: fix typo in the `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module.exports = {
 "@netlify/eslint-config-node/.prettierrc.json"
 ```
 
-- Copy the `commitlint.config.cjs`, `.editorconfig` and `.gitattributes` files relativity to the root of the project.
+- Copy the `commitlint.config.cjs`, `.editorconfig` and `.gitattributes` files to the root of the project.
 - Add the following properties to the `package.json`. Please replace the `config` globbing expressions to match the
   files where the source JavaScript/Markdown/HTML/JSON/YAML files are located. `npm run format` should also be run
   during `npm test` and `npm run format:ci` during CI


### PR DESCRIPTION
This fixes a typo in the `README.md`.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
