### PR TITLE
fix: missing export for Prettier configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@netlify/eslint-config-node",
   "version": "5.0.0",
   "type": "commonjs",
-  "exports": "./.eslintrc.cjs",
+  "exports": {
+    ".": "./.eslintrc.cjs",
+    "./.prettierrc.json": "./.prettierrc.json"
+  },
   "main": "./.eslintrc.cjs",
   "files": [
     ".eslintrc.cjs",


### PR DESCRIPTION
When using the `exports` field in `package.json`, it becomes forbidden to import files that are not explicitly declared as exported.
We have just added that field but we forgot to declare `.prettierrc.json` as exported, since consumers import it.
This is making CI tests of consumers of `@netlify/eslint-config-node` fail ([example](https://github.com/netlify/netlify-redirect-parser/runs/5038065830?check_suite_focus=true)).

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
