### PR TITLE
feat: add ESM-specific rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -377,6 +377,7 @@ module.exports = {
         // Documentation might import dependencies not in package.json
         'node/no-unpublished-require': 0,
         'node/no-extraneous-require': 0,
+        'node/no-extraneous-import': 0,
         'import/no-extraneous-dependencies': 0,
       },
     },

--- a/.eslintrc_esm.cjs
+++ b/.eslintrc_esm.cjs
@@ -1,0 +1,15 @@
+const baseEslintrc = require('./.eslintrc')
+
+// ESLint configuration for packages using pure ES modules.
+// This should be merged to the main `.eslintrc.js` once all our repositories
+// have migrated to pure ES modules.
+module.exports = {
+  ...baseEslintrc,
+  parserOptions: {
+    sourceType: 'module',
+  },
+  rules: {
+    ...baseEslintrc.rules,
+    'import/extensions': [2, 'ignorePackages'],
+  },
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If you're creating a new repository, you can use the
   specific project.
 
 ```js
+// Use '@netlify/eslint-config-node/esm' if the repository is using pure ES modules
 const { overrides } = require('@netlify/eslint-config-node')
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "type": "commonjs",
   "exports": {
     ".": "./.eslintrc.cjs",
+    "./esm": "./.eslintrc_esm.cjs",
     "./.prettierrc.json": "./.prettierrc.json"
   },
   "main": "./.eslintrc.cjs",
   "files": [
     ".eslintrc.cjs",
+    ".eslintrc_esm.cjs",
     ".prettierrc.json",
     ".editorconfig",
     ".gitattributes",


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/36

Most of our repositories have migrated to pure ES modules. However, a few are still using CommonJS.
To accommodate with both and transition incrementally, this PR adds a new `.eslintrc` that contains rules specific to repositories which have migrated to pure ES modules.

Those will need to opt-in to it by switching from `require('@netlify/eslint-config-node')` to `require('@netlify/eslint-config-node/esm')`. After switching, they will also be able to clean up a few rules in their `.eslintrc`.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
