### PR TITLE
fix: missing file extension with ESM configuration

### DIFF
--- a/.eslintrc_esm.cjs
+++ b/.eslintrc_esm.cjs
@@ -1,4 +1,6 @@
-const baseEslintrc = require('./.eslintrc')
+// CommonJS allows omitting `.js` but not `.cjs`
+// eslint-disable-next-line import/extensions
+const baseEslintrc = require('./.eslintrc.cjs')
 
 // ESLint configuration for packages using pure ES modules.
 // This should be merged to the main `.eslintrc.js` once all our repositories


### PR DESCRIPTION
Omitting the file extension when using `require()` only works for `.js`, not `.cjs`. Therefore, the new ESM-specific ESLint configuration currently crashes. 
This PR fixes this.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
