### PR TITLE
fix: ESM-specific configuration bugs

### DIFF
--- a/.eslintrc_esm.cjs
+++ b/.eslintrc_esm.cjs
@@ -8,6 +8,7 @@ const baseEslintrc = require('./.eslintrc.cjs')
 module.exports = {
   ...baseEslintrc,
   parserOptions: {
+    ...baseEslintrc.parserOptions,
     sourceType: 'module',
   },
   rules: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "commonjs",
   "exports": {
     ".": "./.eslintrc.cjs",
-    "./esm": "./.eslintrc_esm.cjs",
+    "./.eslintrc_esm.cjs": "./.eslintrc_esm.cjs",
     "./.prettierrc.json": "./.prettierrc.json"
   },
   "main": "./.eslintrc.cjs",


### PR DESCRIPTION
We have just added an ESM-specific configuration file.

I tried to use the new `exports` feature which allows the import name to be different from the file path being imported. However, this seems to fail with ESLint and report a "module not found" error. When making the import name mirror the imported file path, this error disappears.

Also, when merging the base ESLint configuration, I forgot to merge its `parserOptions`.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
