### PR TITLE
feat!: double max complexity

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,7 +28,7 @@ module.exports = {
     'arrow-body-style': 2,
     'block-scoped-var': 2,
     'class-methods-use-this': 2,
-    complexity: [2, 5],
+    complexity: [2, { max: 5 }],
     'consistent-this': 2,
     'default-case': 2,
     'default-param-last': 2,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,7 +28,7 @@ module.exports = {
     'arrow-body-style': 2,
     'block-scoped-var': 2,
     'class-methods-use-this': 2,
-    complexity: [2, { max: 5 }],
+    complexity: [2, { max: 10 }],
     'consistent-this': 2,
     'default-case': 2,
     'default-param-last': 2,


### PR DESCRIPTION
As discussed in the guild sync, we're doubling the maximum allowed complexity to see if it still bothers us afterwards. This is a breaking change, as it may make existing `eslint-disable` comments error out.