### PR TITLE
[bug]: override conflicting semicolon rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -389,6 +389,9 @@ module.exports = {
         'plugin:@typescript-eslint/recommended',
         'plugin:import/typescript',
       ],
+      rules: {
+        '@typescript-eslint/no-extra-semi': 'off',
+      }
     },
     // React
     {


### PR DESCRIPTION
There appears to be a conflict between [`@typescript-eslint/no-extra-semi`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended.ts#L19) (which is part of the [`@typescript-eslint/recommended`](https://github.com/netlify/eslint-config-node/blob/main/.eslintrc.cjs#L389) config) and the prettier rule [`semi: false`](https://github.com/netlify/eslint-config-node/blob/main/.prettierrc.json#L2).

The [prettier rule](https://prettier.io/docs/en/options.html#semicolons) will add a semicolon in the following instance to protect from [ASI failures](https://prettier.io/docs/en/rationale.html#semicolons).

https://github.com/netlify/next-runtime/blob/main/packages/runtime/src/helpers/config.ts#L95

However, the linter then complains because of the `no-extra-semi` rule.

Since we are removing semicolons anyway, I think we can safely disable the `no-extra-semi` rule.